### PR TITLE
BXC-5587 - Strip file metadata if fail to convert or save file

### DIFF
--- a/normalize.py
+++ b/normalize.py
@@ -33,6 +33,7 @@ print(f'For types: {extensions}')
 
 config = Config()
 config.max_dimension = args.max_dimension
+config.min_dimension = args.min_dimension
 config.output_base_path = args.output_path
 config.src_base_path = args.base_src_path
 config.force = args.force

--- a/src/tests/test_image_normalizer.py
+++ b/src/tests/test_image_normalizer.py
@@ -3,6 +3,7 @@ from PIL import Image
 from src.utils.image_normalizer import ImageNormalizer
 from src.utils.config import Config
 from pathlib import Path
+from unittest.mock import patch
 import shutil
 
 @pytest.fixture
@@ -115,7 +116,7 @@ class TestImageNormalizer:
     src_img = Image.new('RGB', (500, 500), 'blue')
     src_img.save(src_path)
     subject = ImageNormalizer(config)
-    
+
     subject.process(src_path)
     result = Image.open(config.output_base_path / 'images/blue.jpg.jpg')
     assert result.width == 500
@@ -128,7 +129,7 @@ class TestImageNormalizer:
     src_img = Image.new('L', (500, 500), 100)
     src_img.save(src_path, 'TIFF')
     subject = ImageNormalizer(config)
-    
+
     subject.process(src_path)
     result = Image.open(config.output_base_path / 'gray.tif.jpg')
     assert result.width == 500
@@ -141,7 +142,7 @@ class TestImageNormalizer:
     src_img = Image.new('RGB', (5000, 4000), 'blue')
     src_img.save(src_path)
     subject = ImageNormalizer(config)
-    
+
     subject.process(src_path)
     result = Image.open(config.output_base_path / 'bigblue.jpg.jpg')
     assert result.width == 512
@@ -154,7 +155,7 @@ class TestImageNormalizer:
     src_img = Image.new('RGB', (500, 500), 'blue')
     src_img.save(src_path)
     subject = ImageNormalizer(config)
-    
+
     subject.process(src_path)
     result = Image.open(config.output_base_path / 'images/blue.jpg.jpg')
     assert result.width == 500
@@ -179,4 +180,42 @@ class TestImageNormalizer:
     assert result.width == 565
     assert result.height == 224
     assert result.mode == 'RGB'
-  
+
+  # Test that files with problematic XMP metadata that cause TypeError
+  # are handled by stripping metadata and retrying
+  def test_process_with_xmp_metadata_error(self, config):
+    src_path = config.src_base_path / 'tiff_with_xmp.tif'
+    src_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Create a test image with XMP metadata
+    src_img = Image.new('RGB', (500, 500), 'red')
+    src_img.info['xmp'] = b'<test>xmp data</test>'
+    src_img.info['icc_profile'] = b'fake_icc_profile'
+    src_img.save(src_path, 'TIFF')
+
+    subject = ImageNormalizer(config)
+
+    # Mock the save method to raise TypeError on first call (simulating XMP bug),
+    # then call the real save method on subsequent calls
+    original_save = Image.Image.save
+    call_count = 0
+
+    def mock_save(self, *args, **kwargs):
+      nonlocal call_count
+      call_count += 1
+      if call_count == 1:
+        # Simulate the PIL XMP concatenation bug
+        raise TypeError("can't concat tuple to bytes")
+      # On retry, call the real save method
+      return original_save(self, *args, **kwargs)
+
+    with patch.object(Image.Image, 'save', mock_save):
+      result_path = subject.process(src_path)
+
+    # Verify the file was created successfully after retry
+    assert result_path.exists()
+    result = Image.open(result_path)
+    assert result.width == 500
+    assert result.height == 500
+    assert result.mode == 'RGB'
+    assert call_count == 2  # First call failed, second succeeded

--- a/src/utils/image_normalizer.py
+++ b/src/utils/image_normalizer.py
@@ -26,20 +26,32 @@ class ImageNormalizer:
       return output_path
 
     with Image.open(path) as img:
-      # Resize before converting, so that we are working with a smaller image to keep down memory usage
-      img = self.resize(img)
+      try:
+        # Resize before converting, so that we are working with a smaller image to keep down memory usage
+        img = self.resize(img)
+      except TypeError:
+        # Some TIFF files have malformed EXIF/XMP metadata that causes PIL to fail during load/resize
+        # Strip the problematic metadata and retry
+        logging.info(f'Stripping metadata from {path} due to resizing error, retrying')
+        img.info.pop('xmp', None)
+        img.info.pop('icc_profile', None)
+        img.info.pop('exif', None)
+        img = self.resize(img)
+
       if img.mode != "RGB":
         img = img.convert("RGB")
+
       # construct path to write to, then save the file
       output_path.parent.mkdir(parents=True, exist_ok=True)
       try:
         img.save(output_path, "JPEG", quality=80)
       except TypeError:
-        # Some TIFF files have metadata that PIL can't handle, so we will retry without the metadata
-        logging.info(f'Stripping metadata from {path} and retrying')
+        # Some TIFF files have metadata that PIL can't handle during JPEG encoding
+        logging.info(f'Stripping remaining metadata from {path} for JPEG save')
         img.info.pop('xmp', None)
         img.info.pop('icc_profile', None)
-        img.save(output_path, "JPEG", quality=80, exif=b"")
+        img.info.pop('exif', None)
+        img.save(output_path, "JPEG", quality=80)
     return output_path
 
   # Constructs an output path based on the input path and configured base paths.

--- a/src/utils/image_normalizer.py
+++ b/src/utils/image_normalizer.py
@@ -32,7 +32,14 @@ class ImageNormalizer:
         img = img.convert("RGB")
       # construct path to write to, then save the file
       output_path.parent.mkdir(parents=True, exist_ok=True)
-      img.save(output_path, "JPEG", quality=80)
+      try:
+        img.save(output_path, "JPEG", quality=80)
+      except TypeError:
+        # Some TIFF files have metadata that PIL can't handle, so we will retry without the metadata
+        logging.info(f'Stripping metadata from {path} and retrying')
+        img.info.pop('xmp', None)
+        img.info.pop('icc_profile', None)
+        img.save(output_path, "JPEG", quality=80, exif=b"")
     return output_path
 
   # Constructs an output path based on the input path and configured base paths.


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-5587

* Fix setting of min_dimensions
* Strip exif and xml metadata fix resize or save operations fail, to handle small subset of images running into TypeErrors during normalization.